### PR TITLE
add function to derive the label name instead of hardcoding a heuristic

### DIFF
--- a/src/Data/Label.hs
+++ b/src/Data/Label.hs
@@ -151,6 +151,7 @@ Amsterdam over exactly two years:
 -- functions from "Data.Label.Maybe".
 
 , mkLabels
+, mkLabelsWith
 , mkLabelsMono
 , mkLabelsNoTypes
 )


### PR DESCRIPTION
Hi, I've been using this patch in my own project, and thought I should commit it upstream.

I think it's pretty essential for integrating fclabels into a large project.  I can't change my record names to fclabels' leading _ convention without breaking tons of code, and the "add 'l' and capitalize next letter" thing violates my local naming conventions.  But if I can use a function to create another convention for label names then I can gradually integrate fclabels.
