### PR TITLE
export mkLabelsWith

### DIFF
--- a/src/Data/Label.hs
+++ b/src/Data/Label.hs
@@ -151,6 +151,7 @@ Amsterdam over exactly two years:
 -- functions from "Data.Label.Maybe".
 
 , mkLabels
+, mkLabelsWith
 , mkLabelsMono
 , mkLabelsNoTypes
 )


### PR DESCRIPTION
Sorry about the confusion, I amended the patch and since github pull requests seem to be keyed on the commit hash, which of course has changed, I thought I should send another pull request.  Anyway, here's the fixed version.

Hi, I've been using this patch in my own project, and thought I should commit it upstream.

I think it's pretty essential for integrating fclabels into a large project. I can't change my record names to fclabels' leading _ convention without breaking tons of code, and the "add 'l' and capitalize next letter" thing violates my local naming conventions. But if I can use a function to create another convention for label names then I can gradually integrate fclabels.
