### PR TITLE
Make fclabels build with GHC HEAD

### DIFF
--- a/src/Data/Label/Abstract.hs
+++ b/src/Data/Label/Abstract.hs
@@ -24,55 +24,55 @@ import Control.Category
 -- | Abstract Point datatype. The getter and setter functions work in some
 -- arrow.
 
-data Point (~>) f i o = Point
-  { _get :: f ~> o
-  , _set :: (i, f) ~> f
+data Point arr f i o = Point
+  { _get :: arr f o
+  , _set :: arr (i, f) f
   }
 
 -- | Modification as a compositon of a getter and setter. Unfortunately,
 -- `ArrowApply' is needed for this composition.
 
-_modify :: ArrowApply (~>) => Point (~>) f i o -> (o ~> i, f) ~> f
+_modify :: ArrowApply arr => Point arr f i o -> arr (arr o i, f) f
 _modify l = proc (m, f) -> do i <- m . _get l -<< f; _set l -< (i, f)
 
 -- | Abstract Lens datatype. The getter and setter functions work in some
 -- arrow. Arrows allow for effectful lenses, for example, lenses that might
 -- fail or use state.
 
-newtype Lens (~>) f a = Lens { unLens :: Point (~>) f a a }
+newtype Lens arr f a = Lens { unLens :: Point arr f a a }
 
 -- | Create a lens out of a getter and setter.
 
-lens :: (f ~> a) -> ((a, f) ~> f) -> Lens (~>) f a
+lens :: (arr f a) -> (arr (a, f) f) -> Lens arr f a
 lens g s = Lens (Point g s)
 
 -- | Get the getter arrow from a lens.
 
-get :: Arrow (~>) => Lens (~>) f a -> f ~> a
+get :: Arrow arr => Lens arr f a -> arr f a
 get = _get . unLens
 
 -- | Get the setter arrow from a lens.
 
-set :: Arrow (~>) => Lens (~>) f a -> (a, f) ~> f
+set :: Arrow arr => Lens arr f a -> arr (a, f) f
 set = _set . unLens
 
 -- | Get the modifier arrow from a lens.
 
-modify :: ArrowApply (~>) => Lens (~>) f o -> (o ~> o, f) ~> f
+modify :: ArrowApply arr => Lens arr f o -> arr (arr o o, f) f
 modify = _modify . unLens
 
-instance ArrowApply (~>) => Category (Lens (~>)) where
+instance ArrowApply arr => Category (Lens arr) where
   id = lens id (arr fst)
   Lens a . Lens b = lens (_get a . _get b) (_modify b . first (curryA (_set a)))
     where curryA f = arr (\i -> f . arr (i,))
   {-# INLINE id #-}
   {-# INLINE (.) #-}
 
-instance Arrow (~>) => Functor (Point (~>) f i) where
+instance Arrow arr => Functor (Point arr f i) where
   fmap f x = Point (arr f . _get x) (_set x)
   {-# INLINE fmap #-}
 
-instance Arrow (~>) => Applicative (Point (~>) f i) where
+instance Arrow arr => Applicative (Point arr f i) where
   pure a  = Point (arr (const a)) (arr snd)
   a <*> b = Point (arr app . (_get a &&& _get b)) (_set b . (arr fst &&& _set a))
   {-# INLINE pure #-}
@@ -80,21 +80,21 @@ instance Arrow (~>) => Applicative (Point (~>) f i) where
 
 -- | Make a 'Point' diverge in two directions.
 
-bimap :: Arrow (~>) => (o' ~> o) -> (i ~> i') -> Point (~>) f i' o' -> Point (~>) f i o
+bimap :: Arrow arr => (arr o' o) -> (arr i i') -> Point arr f i' o' -> Point arr f i o
 bimap f g l = Point (f . _get l) (_set l . first g)
 
 infix 8 `for`
 
-for :: Arrow (~>) => (i ~> o) -> Lens (~>) f o -> Point (~>) f i o
+for :: Arrow arr => (arr i o) -> Lens arr f o -> Point arr f i o
 for p = bimap id p . unLens
 
--- | The bijections datatype, an arrow that works in two directions. 
+-- | The bijections datatype, an arrow that works in two directions.
 
-data Bijection (~>) a b = Bij { fw :: a ~> b, bw :: b ~> a }
+data Bijection arr a b = Bij { fw :: arr a b, bw :: arr b a }
 
 -- | Bijections as categories.
 
-instance Category (~>) => Category (Bijection (~>)) where
+instance Category arr => Category (Bijection arr) where
   id = Bij id id
   Bij a b . Bij c d = Bij (a . c) (d . b)
   {-# INLINE id #-}
@@ -109,18 +109,18 @@ liftBij a = Bij (fmap (fw a)) (fmap (bw a))
 
 infixr 8 `iso`
 
-class Iso (~>) f where
-  iso :: Bijection (~>) a b -> f a ~> f b
+class Iso arr f where
+  iso :: Bijection arr a b -> arr (f a) (f b)
 
 -- | We can diverge 'Lens'es using an isomorphism.
 
-instance Arrow (~>) => Iso (~>) (Lens (~>) f) where
+instance Arrow arr => Iso arr (Lens arr f) where
   iso bi = arr ((\a -> lens (fw bi . _get a) (_set a . first (bw bi))) . unLens)
   {-# INLINE iso #-}
 
 -- | We can diverge 'Bijection's using an isomorphism.
 
-instance Arrow (~>) => Iso (~>) (Bijection (~>) a) where
+instance Arrow arr => Iso arr (Bijection arr a) where
   iso = arr . (.)
   {-# INLINE iso #-}
 

--- a/src/Data/Label/Derive.hs
+++ b/src/Data/Label/Derive.hs
@@ -151,9 +151,9 @@ derive makeLabel signatures concrete tyname vars total ((field, _, fieldtyp), ct
     tvToVarT _            = fclError "No support for special-kinded type variables."
 
     -- Prettify type variables.
-    arrow          = varT (mkName "~>")
+    arrow          = varT (mkName "arr")
     prettyVars     = map prettyTyVar vars
-    forallVars     = PlainTV (mkName "~>") : prettyVars
+    forallVars     = PlainTV (mkName "arr") : prettyVars
     prettyFieldtyp = prettyType fieldtyp
 
     -- Q style record updating.


### PR DESCRIPTION
When trying to build on HEAD I receive errors such as:

```
src/Data/Label/Derive.hs:141:15:
    Ambiguous constraint `Arrow t0'
      At least one of the forall'd type variables mentioned by the constraint
      must be reachable from the type after the '=>'
    In the Template Haskell quotation
      [t| Arrow $arrow =>
          Lens $arrow $inputType $(return prettyFieldtyp) |]
    In the third argument of `forallT', namely
      `[t| Arrow $arrow =>
           Lens $arrow $inputType $(return prettyFieldtyp) |]'
    In the expression:
      forallT
        forallVars
        (return [])
        [t| Arrow $arrow =>
            Lens $arrow $inputType $(return prettyFieldtyp) |]
```

Consequently I've patched the offending lines to use the functions of Language.Haskell.TH instead of the type quotations.
