### PR TITLE
Fix compilation for GHC7.6

### DIFF
--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -49,7 +49,7 @@ Library
   GHC-Options: -Wall
   Build-Depends:
       base                       < 5
-    , template-haskell >= 2.2 && < 2.8
+    , template-haskell >= 2.2 && < 2.9
     , mtl              >= 1.0 && < 2.2
     , transformers     >= 0.2 && < 0.4
 

--- a/src/Data/Label/Derive.hs
+++ b/src/Data/Label/Derive.hs
@@ -5,6 +5,7 @@
   , FlexibleContexts
   , FlexibleInstances
   , TypeOperators
+  , CPP
   #-}
 module Data.Label.Derive
 ( mkLabels
@@ -122,7 +123,14 @@ derive makeLabel signatures concrete tyname vars total ((field, _, fieldtyp), ct
   where
 
     -- Generate an inline declaration for the label.
-    inline = PragmaD (InlineP labelName (InlineSpec True True (Just (True, 0))))
+    --
+    -- Type of InlineSpec changed in TH-2.8.0 (GHC 7.6)
+#if MIN_VERSION_template_haskell(2,8,0)
+    doInline = Inline
+#else
+    doInline = True
+#endif
+    inline = PragmaD (InlineP labelName (InlineSpec doInline True (Just (True, 0))))
     labelName = mkName (makeLabel (nameBase field))
 
     -- Build a single record label definition for labels that might fail.


### PR DESCRIPTION
- Bump version for TH
- Work around of change in the InlineSpec data type

Builds succesfully with GHC 7.4 and 7.6 RC1
