### PR TITLE
Unbreak fclabels for clang

### DIFF
--- a/src/Data/Label/Derive.hs
+++ b/src/Data/Label/Derive.hs
@@ -5,8 +5,7 @@
   , FlexibleContexts
   , FlexibleInstances
   , TypeOperators
-  , CPP
-  #-}
+  , CPP #-}
 module Data.Label.Derive
 ( mkLabels
 , mkLabel


### PR DESCRIPTION
http://ghc.haskell.org/trac/ghc/ticket/7678 tracks a similar bug with clang. The error message is:

src/Data/Label/Derive.hs:9:4:
     error: invalid preprocessing directive
      #-}
       ^
1 error generated.
