### PR TITLE
Ghc 8 support (again)

### DIFF
--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -107,5 +107,5 @@ Test-Suite suite
     , fclabels
     , template-haskell >= 2.2 && < 2.11
     , mtl              >= 1.0 && < 2.3
-    , transformers     >= 0.2 && < 0.5
+    , transformers     >= 0.2 && < 0.6
     , HUnit            >= 1.2 && < 1.4

--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -88,8 +88,8 @@ Library
 
   GHC-Options: -Wall
   Build-Depends:
-      base             >= 4.6 && < 4.9
-    , template-haskell >= 2.2 && < 2.11
+      base             >= 4.6 && < 4.10
+    , template-haskell >= 2.2 && < 2.12
     , mtl              >= 1.0 && < 2.3
     , transformers     >= 0.2 && < 0.6
 
@@ -105,7 +105,7 @@ Test-Suite suite
   Build-Depends:
       base                       < 5
     , fclabels
-    , template-haskell >= 2.2 && < 2.11
+    , template-haskell >= 2.2 && < 2.12
     , mtl              >= 1.0 && < 2.3
     , transformers     >= 0.2 && < 0.6
     , HUnit            >= 1.2 && < 1.4

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -129,6 +129,16 @@ _Gh :: (ArrowApply cat                                ) => Poly.Lens cat (Gadt (
 
 _Ga = lGa; _Gb = lGb; _Gc = lGc; _Gd = lGd; _Ge = lGe; _Gf = lGf; _Gg = lGg; _Gh = lGh;
 
+data Gadt2 a b where
+  C7, C8 :: { gi :: b, gj :: a } -> Gadt2 a b
+
+mkLabel ''Gadt2
+
+_Gi :: (ArrowApply cat, ArrowChoice cat, ArrowZero cat) => Poly.Lens cat (Gadt2 a b -> Gadt2 a c) (b -> c)
+_Gj :: (ArrowApply cat, ArrowChoice cat, ArrowZero cat) => Poly.Lens cat (Gadt2 a b -> Gadt2 c b) (a -> c)
+
+_Gi = lGi; _Gj = lGj;
+
 -------------------------------------------------------------------------------
 
 -- These instance are needed for the `Failing.Lens String` instance,


### PR DESCRIPTION
I started working on this due to #30, but ended up writing the changes from scratch to understand things better. It turns out that due to the way the representation of GADTs has changed (from a data type with an equality constraint in the context, to a special constructor with the result type) there are some changes in the code generation required. Additionally, the transformers 0.5 release removed the `MonadPlus (Either String)` instance needed for `Failing.Lens String`. I've moved the instance into the test suite for now, but perhaps we consider moving to `Except` there at some point.

The last thing that remains to be done, is that the `total` boolean doesn't seem to be computed correctly for GADTs at this point for GHC 8, resulting in warnings in the generated code that weren't there before. I haven't looked at that yet, I'll rebase this when I've fixed that.