### PR TITLE
Allow building with GHC 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -86,8 +86,8 @@ Library
 
   GHC-Options: -Wall
   Build-Depends:
-      base             >= 4.5 && < 4.10
-    , template-haskell >= 2.2 && < 2.12
+      base             >= 4.5 && < 4.11
+    , template-haskell >= 2.2 && < 2.13
     , mtl              >= 1.0 && < 2.3
     , transformers     >= 0.2 && < 0.6
 
@@ -103,7 +103,7 @@ Test-Suite suite
   Build-Depends:
       base                       < 5
     , fclabels
-    , template-haskell >= 2.2 && < 2.12
+    , template-haskell >= 2.2 && < 2.13
     , mtl              >= 1.0 && < 2.3
     , transformers     >= 0.2 && < 0.6
     , HUnit            >= 1.2 && < 1.7


### PR DESCRIPTION
`fclabels` works out of the box, provided you bump some upper version bounds.