### PR TITLE
Use base-orphans to provide Functor, Applicative, Monad instances for Kleisli

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 CHANGELOG
 
+next
+
+  - Import Functor, Applicative, and Monad instances for Kleisli from the
+    base-orphans package.
+
 2.0.3.3
 
   - Allow GHC 8.4 pre-releases.

--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -86,10 +86,11 @@ Library
 
   GHC-Options: -Wall
   Build-Depends:
-      base             >= 4.5 && < 4.14
-    , template-haskell >= 2.2 && < 2.16
-    , mtl              >= 1.0 && < 2.3
-    , transformers     >= 0.2 && < 0.6
+      base             >= 4.5   && < 4.14
+    , base-orphans     >= 0.8.2 && < 0.9
+    , template-haskell >= 2.2   && < 2.16
+    , mtl              >= 1.0   && < 2.3
+    , transformers     >= 0.2   && < 0.6
 
 Source-Repository head
   Type:     git

--- a/src/Data/Label/Point.hs
+++ b/src/Data/Label/Point.hs
@@ -2,8 +2,6 @@
 basis for vertical composition using the `Applicative` type class.
 -}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 {-# LANGUAGE
     TypeOperators
   , Arrows
@@ -38,6 +36,7 @@ where
 import Control.Arrow
 import Control.Applicative
 import Control.Category
+import Data.Orphans ()
 import Prelude hiding ((.), id, const, curry, uncurry)
 
 {-# INLINE get      #-}
@@ -153,25 +152,6 @@ instance ArrowFail e Partial where
 instance ArrowFail e (Failing e) where
   failArrow = Kleisli Left
   {-# INLINE failArrow #-}
-
--------------------------------------------------------------------------------
-
--- | Missing Functor instance for Kleisli.
-
-instance Functor f => Functor (Kleisli f i) where
-  fmap f (Kleisli m) = Kleisli (fmap f . m)
-
--- | Missing Applicative instance for Kleisli.
-
-instance Applicative f => Applicative (Kleisli f i) where
-  pure a = Kleisli (const (pure a))
-  Kleisli a <*> Kleisli b = Kleisli ((<*>) <$> a <*> b)
-
--- | Missing Alternative instance for Kleisli.
-
-instance Alternative f => Alternative (Kleisli f i) where
-  empty = Kleisli (const empty)
-  Kleisli a <|> Kleisli b = Kleisli ((<|>) <$> a <*> b)
 
 -------------------------------------------------------------------------------
 -- Common operations experessed in a generalized form.


### PR DESCRIPTION
GHC 8.10 will feature `Functor`, `Applicative`, and `Monad` instances for `Kleisli`. Unfortunately, this will break `fclabels-2.0.3.3`, which defines these instances as orphans in `Data.Label.Point`. To achieve forward compatibility with GHC 8.10, this patch removes these orphan instances and replaces them with an import to `Data.Orphans` from the `base-orphans` package, which provides a canonical home for orphan instances for types in `base`. On 8.10 or later, this will simply use the `Kleisli` instances from `base`, but on older versions of GHC, `base-orphans` will fall back on equivalent orphan instances.