### PR TITLE
add support for ghc 9.0.1

### DIFF
--- a/fclabels.cabal
+++ b/fclabels.cabal
@@ -86,9 +86,9 @@ Library
 
   GHC-Options: -Wall
   Build-Depends:
-      base             >= 4.5   && < 4.15
+      base             >= 4.5   && < 4.16
     , base-orphans     >= 0.8.2 && < 0.9
-    , template-haskell >= 2.2   && < 2.17
+    , template-haskell >= 2.2   && < 2.18
     , mtl              >= 1.0   && < 2.3
     , transformers     >= 0.2   && < 0.6
 


### PR DESCRIPTION
There was a template-haskell version bump that changed TyVarBndr.
This is a pretty awful bunch of CPP.  I tried to clean up PlainTV and
KindedTv with PatternSynonyms, but apparently they don't let you provide
or throw away a dummy variable.